### PR TITLE
Add node_modules to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+node_modules
+npm-debug.log
 .storybook/blabbr-config.js


### PR DESCRIPTION
This PR enhances the project by adding 2 standard entries to `.gitignore` file. In its absence, the `node_modules` folder shows up in diff and would get in the way of checking in any potential changes in future.